### PR TITLE
Add regression tests for PPTX generator

### DIFF
--- a/tests/test_data/carte.html
+++ b/tests/test_data/carte.html
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><!--This file has been created with freeplane2html.xsl--><head><title>Mind Map</title><link rel="stylesheet" href="carte.html_files/freeplane2html.css" type="text/css" /><meta name="generator" content="Freeplane-XSL Stylesheet (see: http://freeplane-xsl.dev.slash-me.net/ for details)" /><script type="text/javascript" src="carte.html_files/freeplane2html.js"> 
+</script><script type="text/javascript"><!--
+          
+               function toggle(id)
+               {
+                   div_el = document.getElementById(id);
+                   img_el = document.getElementById('img'+id);
+                   if (div_el.style.display != 'none')
+                   {
+          
+
+                      div_el.style.display='none';
+                      img_el.src = 'carte.html_files/show.png';
+          
+                   }
+                   else
+                   {
+          
+                      div_el.style.display='block';
+                      img_el.src = 'carte.html_files/hide.png';
+          
+                   };
+               };
+          
+          --></script></head><body><h1>Mind Map</h1><div style="width:96%;  padding:2%;  margin-bottom:10px;  border: 0px;  text-align:center;  vertical-align:center;"><img src="carte.html_files/image.png" style="margin-bottom:10px; border: 0px; text-align:center; vertical-align:center;" alt="Imagemap" usemap="#fm_imagemap" /></div><map name="fm_imagemap" id="fm_imagemap"><area shape="rect" href="#FMID_696401721FM" alt="Nouvelle carte" title="Nouvelle carte" coords="140,50,412,108" />
+<area shape="rect" href="#FMID_777443754FM" alt="aze" title="aze" coords="437,67,502,91" />
+<area shape="rect" href="#FMID_1015226095FM" alt="" title="" coords="100,53,115,77" />
+<area shape="rect" href="#FMID_1802503929FM" alt="aze" title="aze" coords="50,81,115,105" />
+</map>
+
+<div class="node"><img src="carte.html_files/hide.png" class="hideshow" alt="hide" onClick="toggle(&quot;N65543&quot;)" id="imgN65543" /><a id="FMID_696401721FM" /><div class="nodecontent" style="color:#000000;font-size:150%;"> </div><div class="content" id="N65543"><div class="node"><img src="carte.html_files/leaf.png" class="hideshow" alt="leaf" /><a id="FMID_777443754FM" /><div class="nodecontent" style="color:#000000;font-size:83%;"><a href="https://news.google.com/search?q=ia&amp;hl=fr&amp;gl=FR&amp;ceid=FR%3Afr">aze</a> <a href="https://news.google.com/search?q=ia&amp;hl=fr&amp;gl=FR&amp;ceid=FR%3Afr"><img src="carte.html_files/ilink.png" alt="User Link" style="border-width:0" /></a></div></div><div class="node"><img src="carte.html_files/leaf.png" class="hideshow" alt="leaf" /><a id="FMID_1015226095FM" /><div class="nodecontent" style="color:#000000;font-size:83%;"> </div></div><div class="node"><img src="carte.html_files/leaf.png" class="hideshow" alt="leaf" /><a id="FMID_1802503929FM" /><div class="nodecontent" style="color:#000000;font-size:83%;"><a href="https://duckduckgo.com/">aze</a> <a href="https://duckduckgo.com/"><img src="carte.html_files/ilink.png" alt="User Link" style="border-width:0" /></a></div></div></div></div>
+</body></html>

--- a/tests/test_generate_clickable_pptx.py
+++ b/tests/test_generate_clickable_pptx.py
@@ -1,0 +1,83 @@
+import os
+import tempfile
+import re
+from pathlib import Path
+
+import pytest
+from pptx import Presentation
+
+from click2pptx.generate_clickable_pptx import (
+    parse_html,
+    create_pptx,
+    find_html,
+    make_output_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sample_html_text():
+    path = Path(__file__).parent / "test_data" / "carte.html"
+    return path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# parse_html
+# ---------------------------------------------------------------------------
+
+def test_parse_html_sample(sample_html_text):
+    clickables, img_src = parse_html(sample_html_text)
+    assert img_src == "carte.html_files/image.png"
+    assert clickables == [
+        ([140, 50, 412, 108], "https://news.google.com/search?q=ia&hl=fr&gl=FR&ceid=FR%3Afr"),
+        ([437, 67, 502, 91], "https://news.google.com/search?q=ia&hl=fr&gl=FR&ceid=FR%3Afr"),
+        ([100, 53, 115, 77], "https://duckduckgo.com/"),
+        ([50, 81, 115, 105], "https://duckduckgo.com/"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# create_pptx
+# ---------------------------------------------------------------------------
+
+def test_create_pptx_creates_shapes(tmp_path):
+    clickables = [([10, 10, 20, 20], "http://example.com")]
+    pptx_path = tmp_path / "test.pptx"
+    create_pptx(clickables, None, pptx_path)
+
+    prs = Presentation(pptx_path)
+    shapes = prs.slides[0].shapes
+    assert len(shapes) == 1
+    assert shapes[0].click_action.hyperlink.address == "http://example.com"
+
+
+# ---------------------------------------------------------------------------
+# find_html
+# ---------------------------------------------------------------------------
+
+def test_find_html_existing(tmp_path):
+    html_file = tmp_path / "foo.html"
+    html_file.write_text("<html></html>", encoding="utf-8")
+    assert find_html(str(html_file)) == str(html_file)
+
+
+def test_find_html_automatic(tmp_path, monkeypatch):
+    html_file = tmp_path / "bar.html"
+    html_file.write_text("<html></html>", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    assert find_html(None) == html_file.name
+
+
+# ---------------------------------------------------------------------------
+# make_output_path
+# ---------------------------------------------------------------------------
+
+def test_make_output_path_creates_folder(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    out_path = make_output_path(None)
+    assert Path(out_path).parent.exists()
+    assert re.match(r"output/mind_map_clickable_\d{8}_\d{6}\.pptx", out_path)
+


### PR DESCRIPTION
## Summary
- add HTML fixture from Freeplane export
- add unit tests for parse_html, create_pptx and IO helpers

## Testing
- `pytest -q`
- `pytest --cov=click2pptx -q`

------
https://chatgpt.com/codex/tasks/task_e_68584cfa36848320be7cc90bead14304