### PR TITLE
Add black linting and coverage measurement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ __pycache__/
 *.pyc
 output/
 *.pptx
+.coverage
+build/
+src/*.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+        args: ["--check"]

--- a/README.md
+++ b/README.md
@@ -36,3 +36,22 @@ The program reads the HTML file, extracts the clickable areas and the
 image used, then generates an equivalent PPTX. Each active region of the
 image is covered by an invisible rectangle with the hyperlink defined in
 the Freeplane export.
+
+## Développement
+
+Installez les dépendances de développement puis mettez en place les hooks
+pré‑commit :
+
+```bash
+pip install .[dev]
+pre-commit install
+```
+
+Le hook `pre-commit` exécute `black` en mode vérification et bloque le commit si
+le formatage n'est pas conforme.
+
+Les tests s'exécutent avec `pytest` et un rapport de couverture est produit :
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,19 @@ dependencies = [
     "python-pptx"
 ]
 
+[project.optional-dependencies]
+dev = [
+    "black",
+    "pre-commit",
+    "pytest",
+    "pytest-cov",
+]
+
+[tool.black]
+target-version = ["py310"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=click2pptx --cov-report=term-missing"
+
 [project.scripts]
 click2pptx = "click2pptx.generate_clickable_pptx:main"

--- a/src/click2pptx/generate_clickable_pptx.py
+++ b/src/click2pptx/generate_clickable_pptx.py
@@ -34,11 +34,13 @@ from pptx.enum.shapes import MSO_SHAPE
 from pptx.util import Emu
 from pptx.dml.color import RGBColor
 from pptx.enum.dml import MSO_FILL
+
 EMU_PER_PX = 9_525  # 1 px → 9 525 EMU (pptx)
 
 # ---------------------------------------------------------------------------#
 # I/O utilities
 # ---------------------------------------------------------------------------#
+
 
 def find_html(path: str | None) -> str:
     """Return the path of the HTML file to process."""
@@ -70,6 +72,7 @@ def make_output_path(path: str | None) -> str:
 # ---------------------------------------------------------------------------#
 # Freeplane HTML parsing
 # ---------------------------------------------------------------------------#
+
 
 def parse_html(html_text: str):
     """
@@ -107,6 +110,7 @@ def parse_html(html_text: str):
 # PPTX generation
 # ---------------------------------------------------------------------------#
 
+
 def create_pptx(clickables, img_src, dest_path):
     prs = Presentation()
     slide = prs.slides.add_slide(prs.slide_layouts[6])
@@ -132,6 +136,7 @@ def create_pptx(clickables, img_src, dest_path):
 # ---------------------------------------------------------------------------#
 # Main program
 # ---------------------------------------------------------------------------#
+
 
 def main():
     ap = argparse.ArgumentParser(

--- a/tests/test_generate_clickable_pptx.py
+++ b/tests/test_generate_clickable_pptx.py
@@ -18,6 +18,7 @@ from click2pptx.generate_clickable_pptx import (
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def sample_html_text():
     path = Path(__file__).parent / "test_data" / "carte.html"
@@ -28,12 +29,19 @@ def sample_html_text():
 # parse_html
 # ---------------------------------------------------------------------------
 
+
 def test_parse_html_sample(sample_html_text):
     clickables, img_src = parse_html(sample_html_text)
     assert img_src == "carte.html_files/image.png"
     assert clickables == [
-        ([140, 50, 412, 108], "https://news.google.com/search?q=ia&hl=fr&gl=FR&ceid=FR%3Afr"),
-        ([437, 67, 502, 91], "https://news.google.com/search?q=ia&hl=fr&gl=FR&ceid=FR%3Afr"),
+        (
+            [140, 50, 412, 108],
+            "https://news.google.com/search?q=ia&hl=fr&gl=FR&ceid=FR%3Afr",
+        ),
+        (
+            [437, 67, 502, 91],
+            "https://news.google.com/search?q=ia&hl=fr&gl=FR&ceid=FR%3Afr",
+        ),
         ([100, 53, 115, 77], "https://duckduckgo.com/"),
         ([50, 81, 115, 105], "https://duckduckgo.com/"),
     ]
@@ -42,6 +50,7 @@ def test_parse_html_sample(sample_html_text):
 # ---------------------------------------------------------------------------
 # create_pptx
 # ---------------------------------------------------------------------------
+
 
 def test_create_pptx_creates_shapes(tmp_path):
     clickables = [([10, 10, 20, 20], "http://example.com")]
@@ -57,6 +66,7 @@ def test_create_pptx_creates_shapes(tmp_path):
 # ---------------------------------------------------------------------------
 # find_html
 # ---------------------------------------------------------------------------
+
 
 def test_find_html_existing(tmp_path):
     html_file = tmp_path / "foo.html"
@@ -75,9 +85,9 @@ def test_find_html_automatic(tmp_path, monkeypatch):
 # make_output_path
 # ---------------------------------------------------------------------------
 
+
 def test_make_output_path_creates_folder(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     out_path = make_output_path(None)
     assert Path(out_path).parent.exists()
     assert re.match(r"output/mind_map_clickable_\d{8}_\d{6}\.pptx", out_path)
-


### PR DESCRIPTION
## Summary
- configure black, pytest coverage and pre-commit in `pyproject.toml`
- add pre-commit config running black in check mode
- document development workflow including linting and coverage
- ignore build artifacts
- format sources with black

## Testing
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858517d8a5c832089787b36b7e7f8ba