### PR TITLE
Add PyInstaller spec file for binary build

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,15 @@ Run the tests with coverage enabled:
 ```bash
 pytest --cov=click2pptx
 ```
+
+## Standalone binary
+
+You can build a standalone executable using PyInstaller and the
+provided `click2pptx.spec` file:
+
+```bash
+pip install pyinstaller
+pyinstaller click2pptx.spec
+```
+
+The resulting binary will be available in the `dist` folder.

--- a/click2pptx.spec
+++ b/click2pptx.spec
@@ -1,0 +1,38 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+a = Analysis(
+    ['src/click2pptx/generate_clickable_pptx.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='click2pptx',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+


### PR DESCRIPTION
## Summary
- provide a `click2pptx.spec` for PyInstaller
- document how to build a standalone binary

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685868659ae883208ff177adf0f744d6